### PR TITLE
Add `is-open` flag on Iglu container

### DIFF
--- a/iglu.js
+++ b/iglu.js
@@ -55,6 +55,7 @@
      */
      function destroy() {
          this.Iglu.documentBody.className=this.Iglu.documentBody.className.replace(' ' + this.Iglu.documentBodyClassName, '');
+         this.Iglu.container.className = this.Iglu.container.className.replace(' is-open', '');
          this.Iglu.container.style.display="none";
          this.Iglu.container.innerHTML="";
          document.getElementsByTagName('html')[0].style='';
@@ -84,6 +85,8 @@
                   '</div>' +
                   '<div class="modal__footer"></div>' +
               '</div>';
+
+              Iglu.container.className = Iglu.container.className + ' is-open';
 
               return Iglu;
           },


### PR DESCRIPTION
As requested by @davidbwaters, I have added a flag to state that the modal is open.

I have not allowed this to be configurable as was slightly suggested as I feel that would add complication to the plugin and logic.

I would like @garethadavies to give some feedback on this in case I have missed a cleaner solution?

@davidbwaters; would you confirm this is what you are after? 

closes #5 